### PR TITLE
fix: wrong indentation in Makefile 'test-ci' target #22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,12 +65,12 @@ test-ci: test-cov ## Run the tests with coverage and check if it's above the thr
 	@echo "Current test coverage : $(ACTUAL_COVERAGE) %"
 
 	@if [ "$(shell echo "$(ACTUAL_COVERAGE) < $(TESTCOVERAGE_THRESHOLD)" | bc -l)" -eq 1 ]; then \
-    echo "Current test coverage is below threshold. Please add more unit tests or adjust threshold to a lower value."; \
-    echo "Failed"; \
-    exit 1; \
-  else \
-    echo "OK"; \
-  fi
+		echo "Current test coverage is below threshold. Please add more unit tests or adjust threshold to a lower value."; \
+		echo "Failed"; \
+		exit 1; \
+	else \
+		echo "OK"; \
+	fi
 
 .PHONY: lint
 lint: ## Run the linting command.


### PR DESCRIPTION
## Fixes issue

Fixes #22

## Changes proposed

Add proper whitespace to shell script in the `test-ci` target.

yourFavoriteIDEorTextEditor := "code"

1. Open yourFavoriteIDEorTextEditor
2. Click on Makefile
3. Select lines between [68, 73]
4. Press shift

## Check List (Check all the applicable boxes)

- [x] The title of my pull request is a short description of the requested changes.
- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] This PR does not contain plagiarized content.
- [x] My submissions follows the **Submission Rules**
- [x] I have read and accepted the **Terms and Conditions**

## Screenshots

Result:

![Screenshot_20250520_193221](https://github.com/user-attachments/assets/5344b74f-d998-49b8-939c-bb43ea1103a0)

